### PR TITLE
seo: add OG tags, Twitter Card, and canonical URL

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,10 +9,18 @@ import '@styles/main.css';
 export interface Props {
   title: string;
   bodyClass?: string | undefined;
+  description?: string;
+  ogImage?: string;
+  canonicalUrl?: string;
 }
 
-const { title,
-  bodyClass = "default", } = Astro.props;
+const {
+  title,
+  bodyClass = "default",
+  description = "Studio Binocle in Milan, Italy was founded by architect Lorenzo Bini.",
+  ogImage,
+  canonicalUrl,
+} = Astro.props;
 ---
 <!doctype html>
 <html lang='en'>
@@ -21,10 +29,17 @@ const { title,
         <Version />
         <meta charset='UTF-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-        <meta
-            name='description'
-            content='Studio Binocle in Milan, Italy was founded by architect Lorenzo Bini.'
-        />
+        <meta name='description' content={description} />
+        {canonicalUrl && <link rel='canonical' href={canonicalUrl} />}
+        <meta property='og:type' content='website' />
+        <meta property='og:site_name' content='Binocle' />
+        <meta property='og:title' content={title} />
+        <meta property='og:description' content={description} />
+        {ogImage && <meta property='og:image' content={ogImage} />}
+        <meta name='twitter:card' content='summary_large_image' />
+        <meta name='twitter:title' content={title} />
+        <meta name='twitter:description' content={description} />
+        {ogImage && <meta name='twitter:image' content={ogImage} />}
         <title>{title}</title>
     </head>
   <body id='top' class={bodyClass}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,13 @@ console.log('this ROKMA|DEV runs in your terminal, not in the browser, neither o
 console.log('SOURCE_FILE: src/pages/index.astro');
 
 import Layout from '@layouts/Layout.astro';
-import { Picture } from 'astro:assets';
+import { Picture, getImage } from 'astro:assets';
 import cover from '@p/cover.jpg';
 const pageTitle = 'BINOCLE | 2025 update';
 const bodyClass = 'home';
+const ogImageObj = await getImage({ src: cover, width: 1200, height: 630, format: 'jpg' });
+const ogImage = new URL(ogImageObj.src, Astro.site).toString();
+const canonicalUrl = new URL('/', Astro.site).toString();
 ---
 
 <style>
@@ -42,7 +45,7 @@ const bodyClass = 'home';
 
 </style>
 
-<Layout title={pageTitle} bodyClass={bodyClass}>
+<Layout title={pageTitle} bodyClass={bodyClass} ogImage={ogImage} canonicalUrl={canonicalUrl}>
   <h1 class='hide'>BINOCLE</h1>
   <main class='bungkus' id="main">
     <div class='home shots' id='also_toggle_works'>

--- a/src/pages/works/[hash].astro
+++ b/src/pages/works/[hash].astro
@@ -3,7 +3,7 @@
 import { getCollection, render } from 'astro:content';
 import { getWorkImagesSync } from '@utils/imageUtils';
 import Layout from '@layouts/Layout.astro';
-import { Picture } from 'astro:assets';
+import { Picture, getImage } from 'astro:assets';
 
 // Generate routes for all works
 export async function getStaticPaths() {
@@ -24,6 +24,12 @@ const { Content } = await render(work);
 const imageUrls = getWorkImagesSync(work.data.hash);
 const firstImage = imageUrls[0];
 const remainingImages = imageUrls.slice(1);
+
+const ogImageObj = firstImage
+  ? await getImage({ src: firstImage, width: 1200, height: 630, format: 'jpg' })
+  : null;
+const ogImage = ogImageObj ? new URL(ogImageObj.src, Astro.site).toString() : undefined;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <style>
@@ -123,7 +129,13 @@ const remainingImages = imageUrls.slice(1);
 
 </style>
 
-<Layout title={work.data.title} bodyClass='work'>
+<Layout
+  title={work.data.title}
+  bodyClass='work'
+  description={work.data.description}
+  ogImage={ogImage}
+  canonicalUrl={canonicalUrl}
+>
   <main class={'bungkus ' + work.data.project} id="main">
     <!-- Display first image before h2 title -->
     {


### PR DESCRIPTION
Sharing a link to binocle.it on social platforms currently shows no preview image. This adds `og:title`, `og:description`, `og:image`, `og:type`, `og:site_name`, `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`, and `rel=canonical` to every page via `Layout.astro` props.

Project pages use the first project photo resized to 1200×630 as OG image (generated via `astro:assets` `getImage`). The homepage uses the cover image. All image URLs are absolute (`https://binocle.it/...`).

**Files changed:** `src/layouts/Layout.astro`, `src/pages/works/[hash].astro`, `src/pages/index.astro`