### PR TITLE
perf: add widths and sizes to homepage hero image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,8 @@ const bodyClass = 'home';
           src={cover}
           formats={['avif', 'webp']}
           alt='Binocle By Lorenzo Bini'
-          layout='constrained'
+          widths={[400, 800, 1200, 1920]}
+          sizes='(max-width: 600px) 100vw, (max-width: 1200px) 80vw, 1200px'
           loading='eager'
         />
       </div>


### PR DESCRIPTION
The cover image (3884×4855px, 7.2 MB) was being served at full resolution even on mobile where it renders at ~400px. Adding explicit `widths` and a `sizes` descriptor lets the browser pick the right srcset variant — on a 400px viewport it will download the 400px variant instead of the 7 MB original.

**Files changed:** `src/pages/index.astro`