### PR TITLE
seo: unique meta description per project page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,10 +9,14 @@ import '@styles/main.css';
 export interface Props {
   title: string;
   bodyClass?: string | undefined;
+  description?: string;
 }
 
-const { title,
-  bodyClass = "default", } = Astro.props;
+const {
+  title,
+  bodyClass = "default",
+  description = "Studio Binocle in Milan, Italy was founded by architect Lorenzo Bini.",
+} = Astro.props;
 ---
 <!doctype html>
 <html lang='en'>
@@ -21,10 +25,7 @@ const { title,
         <Version />
         <meta charset='UTF-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-        <meta
-            name='description'
-            content='Studio Binocle in Milan, Italy was founded by architect Lorenzo Bini.'
-        />
+        <meta name='description' content={description} />
         <title>{title}</title>
     </head>
   <body id='top' class={bodyClass}>

--- a/src/pages/works/[hash].astro
+++ b/src/pages/works/[hash].astro
@@ -123,7 +123,7 @@ const remainingImages = imageUrls.slice(1);
 
 </style>
 
-<Layout title={work.data.title} bodyClass='work'>
+<Layout title={work.data.title} bodyClass='work' description={work.data.description}>
   <main class={'bungkus ' + work.data.project} id="main">
     <!-- Display first image before h2 title -->
     {


### PR DESCRIPTION
All 30 project pages were sharing the same generic description ("Studio Binocle in Milan..."). Each markdown file already has a `description` field in its frontmatter — this wires it through `Layout.astro` so each page gets its own copy. The homepage keeps the generic default.

**Files changed:** `src/layouts/Layout.astro`, `src/pages/works/[hash].astro`